### PR TITLE
Add constructors with custom message

### DIFF
--- a/BetterWin32Errors/Win32Exception.cs
+++ b/BetterWin32Errors/Win32Exception.cs
@@ -28,6 +28,11 @@ namespace BetterWin32Errors
         public string ErrorMessage { get; private set; }
 
         /// <summary>
+        /// Custom message which can be utilized in logic code.
+        /// </summary>
+        public string CustomMessage { get; private set; }
+
+        /// <summary>
         /// Create a new exception using the value from <see cref="GetLastWin32Error"/>. Note: make sure to set SetLastError=true on <see cref="DllImportAttribute"/>.
         /// </summary>
         public Win32Exception()
@@ -36,12 +41,33 @@ namespace BetterWin32Errors
         }
 
         /// <summary>
+        /// Create a new exception with given error code.
         /// </summary>
         public Win32Exception(Win32Error error)
             : base($"{error}: {GetMessage(error)}")
         {
             Error = error;
             ErrorMessage = GetMessage(error);
+        }
+
+        /// <summary>
+        /// Create a new exception using the value from <see cref="GetLastWin32Error"/> and custom message. Note: make sure to set SetLastError=true on <see cref="DllImportAttribute"/>.
+        /// </summary>
+        public Win32Exception(string customMessage)
+            : this(GetLastWin32Error())
+        {
+            CustomMessage = customMessage;
+        }
+
+        /// <summary>
+        /// Create a new exception with given error code and custom message
+        /// </summary>
+        public Win32Exception(Win32Error error, string customMessage)
+            : base($"{error}: {GetMessage(error)}")
+        {
+            Error = error;
+            ErrorMessage = GetMessage(error);
+            CustomMessage = customMessage;
         }
 
         static string GetMessage(Win32Error error)


### PR DESCRIPTION
System.ComponentModel.Win32Exception can get custom message as arugment.

This patch enables to use custom message while using BetterWin32Errors.Win32Exception.

Property ```string CustomMessage``` has added to Win32Exception.

Ex)
```csharp
if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, out hToken))
{
    throw new BetterWin32Errors.Win32Exception("OpenProcessToken failed");
}
```